### PR TITLE
datx 版数据库的offset 会超过 16777215 (0xFFFFFFFF)

### DIFF
--- a/lib/datx.js
+++ b/lib/datx.js
@@ -45,7 +45,7 @@ Datx.prototype.lookup = function(ip) {
       // found
       offset += BLOCK_SIZE;
       var index = this.buffer.readInt32LE(offset + 4) >>> 0;
-      var recordOffset = (index & 0x00FFFFFF) + this.len - HEADER_SIZE;
+      var recordOffset = (index & 0xFFFFFFFF) + this.len - HEADER_SIZE;
       var recordLength = this.buffer.readUInt8(offset + LEN_OFFSET);
       return this.buffer.slice(recordOffset, recordOffset + recordLength).toString().split('\t');
     }


### PR DESCRIPTION
datx 版用 4个字节保存 offset 信息，其实也没必要 像 dat 版一样做 (index & 0xFFFFFFFF) 运算